### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
-#Schema UI Framework
+# Schema UI Framework
 Schema is a modular, responsive, front end framework to easily and quickly help you jumpstart your process in building complex interfaces for the web right out the box. It was created by [Dan Malarkey](http://danmalarkey.com) and the [feature[23]] (http://feature23.com) team. 
 
 Learn more about Schema and how to use it by [reviewing the documentation]( 
 http://danmalarkey.github.io/schema/).
 
-##Get Started
+## Get Started
 - Download [the latest release of Schema](https://github.com/danmalarkey/schema/releases/tag/2.0.0)
 - Clone the repo locally ```$ git clone https://github.com/danmalarkey/schema.git```
 - Install with Bower ```$ bower install schema-ui```
 
-##Schema Documentation
+## Schema Documentation
 Download and use Schema at:
 http://danmalarkey.github.io/schema/
 
-##Bugs
+## Bugs
 If you find bugs please [review the issues section](https://github.com/danmalarkey/schema/issues) to verify no one else has reported it. If not, please [create a new issue](https://github.com/danmalarkey/schema/issues/new) and label it accordingly.
 
-##Versioning
+## Versioning
 I'm new to developing and maintaining software, but I'm going to try my best (I'm sure I'll screw something up) to stick to [semantic versioning](http://semver.org/).
 
-##Changelog Releases
+## Changelog Releases
 As of v2 I will be documenting releases much more than I did with version one. [Check out the releases during development](https://github.com/danmalarkey/schema/releases)
 
-##License
+## License
 - Schema is licensed under the MIT License - http://opensource.org/licenses/MIT
 - EasyDropdown by Patrick Kunka is licensed under License: Creative Commons Attribution 3.0 Unported - CC BY 3.0 - http://creativecommons.org/licenses/by/3.0/
 
-##Contact
+## Contact
 - Email: hello@danmalarkey.com
 - Twitter: http://twitter.com/dan_malarkey
 - Headquartered: http://feature23.com


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
